### PR TITLE
Fix: nicely print values with allow and valid

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -298,7 +298,8 @@ internals.getParamsData = function (param, name) {
             insensitive: param.flags.insensitive, // string specific
             required: param.flags.presence === 'required',
             forbidden: param.flags.presence === 'forbidden',
-            stripped: param.flags.strip
+            stripped: param.flags.strip,
+            allowOnly: param.flags.allowOnly
         }
     };
 

--- a/templates/helpers/type.js
+++ b/templates/helpers/type.js
@@ -16,14 +16,33 @@ module.exports = function (isAlternative) {
     }
 
     if (this.allowedValues) {
-        if (!this.name || this.allowedValues.length === 1) {
-            // Used for array and alternatives rendering
-            type = this.allowedValues;
+        // Used for array and alternatives rendering
+        if (!this.name) {
+            type = this.allowedValues.join(', ');
         }
+
+        // with only one `.valid()`, just show that, it's the only possiblity
+        else if (this.allowedValues.length === 1
+            && this.flags
+            && this.flags.allowOnly) {
+            type = this.allowedValues[0];
+        }
+
+        // with multiple `.valid()` values, delcare it must be one of those
+        else if (this.flags && this.flags.allowOnly) {
+            type = `<span class="text-danger">must be one of</span> <span>${this.allowedValues.join(', ')}</span>`;
+        }
+
+        // if there's a single allowedValue and it's not required
+        else if (this.allowedValues.length === 1) {
+            type += ` (<span class="text-danger">can also be</span> <span>${this.allowedValues[0]}</span>)`;
+        }
+
+        // if there's allowedValues, but they're not required
         else {
-            type = `<span class="text-danger">one of</span> <span>${this.allowedValues.join(', ')}</span>`;
+            type += ` (<span class="text-danger">can also be one of</span> <span>${this.allowedValues.join(', ')}</span>)`;
         }
     }
 
-    return new Handlebars.SafeString(`<span class="field-type">${type}</span>`);
+    return new Handlebars.SafeString(`<span class="field-type">${type.trim()}</span>`);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -186,6 +186,53 @@ describe('Lout', () => {
         });
     });
 
+    it('shows a single value with only one valid', (done) => {
+
+        server.inject('/docs?server=http://test&path=/only-one-valid', (res) => {
+
+            expect(res.result).to.contain('onlyvalid');
+
+            done();
+        });
+    });
+
+    it('shows multiple values with multiple valids', (done) => {
+
+        server.inject('/docs?server=http://test&path=/multiple-valids', (res) => {
+
+            expect(res.result).to.contain('must be one of');
+            expect(res.result).to.contain('onlyvalid');
+            expect(res.result).to.contain('metoo');
+
+            done();
+        });
+    });
+
+    it('shows a single value on a single allow', (done) => {
+
+        server.inject('/docs?server=http://test&path=/single-allow', (res) => {
+
+            expect(res.result).to.contain('string');
+            expect(res.result).to.contain('can also be');
+            expect(res.result).to.contain('alsoallow');
+
+            done();
+        });
+    });
+
+    it('shows multiple values on multiple allows', (done) => {
+
+        server.inject('/docs?server=http://test&path=/multiple-allows', (res) => {
+
+            expect(res.result).to.contain('number');
+            expect(res.result).to.contain('can also be one of');
+            expect(res.result).to.contain('null');
+            expect(res.result).to.contain('alsoallow');
+
+            done();
+        });
+    });
+
     it('returns a Not Found response when wrong path is provided', (done) => {
 
         server.inject('/docs?server=http://test&path=blah', (res) => {

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -189,6 +189,50 @@ module.exports = [{
     }
 }, {
     method: 'GET',
+    path: '/only-one-valid',
+    config: {
+        handler,
+        validate: {
+            query: Joi.object({
+                param1: Joi.string().valid('onlyvalid')
+            })
+        }
+    }
+}, {
+    method: 'GET',
+    path: '/multiple-valids',
+    config: {
+        handler,
+        validate: {
+            query: Joi.object({
+                param1: Joi.string().valid('onlyvalid', 'metoo')
+            })
+        }
+    }
+}, {
+    method: 'GET',
+    path: '/single-allow',
+    config: {
+        handler,
+        validate: {
+            query: Joi.object({
+                param1: Joi.string().allow('alsoallow')
+            })
+        }
+    }
+}, {
+    method: 'GET',
+    path: '/multiple-allows',
+    config: {
+        handler,
+        validate: {
+            query: Joi.object({
+                param1: Joi.number().allow(null, 'alsoallow')
+            })
+        }
+    }
+}, {
+    method: 'GET',
     path: '/withnestedalternatives',
     config: {
         handler,


### PR DESCRIPTION
Previously, if you used `valid` or `allow`, and only had one value, lout
would show just that value. This was very inconvenient if the additional
value was `null`. It looks like the only valid value is `null` :\

This change get smart about `valid` and `allow`, and deals with multiple
values.
1. If you only have one value and use `valid`, we just show that value.
   It's the only possibility (this is current behavior).
2. If you use `valid`, but have multiple values, we show all of them,
   but specify that the value must be one the list.
3. If you use `allow` and specify one value, we show the type and note
   that the value "can also be" the additional value.
4. If you use `allow` and specify multiple values, we show the type and
   note that the value "can also be one of" the additional values.
